### PR TITLE
#1 - Should use type hints to distinguish methods of same arity and d…

### DIFF
--- a/test/java/com/rpl/InterfaceA.java
+++ b/test/java/com/rpl/InterfaceA.java
@@ -1,0 +1,5 @@
+package com.rpl;
+
+public interface InterfaceA {
+  String bar(Integer x, Integer y, long z);
+}

--- a/test/java/com/rpl/InterfaceAB.java
+++ b/test/java/com/rpl/InterfaceAB.java
@@ -1,0 +1,9 @@
+package com.rpl;
+
+public interface InterfaceAB extends InterfaceA, InterfaceB {
+  int baz();
+  int baz(long p);
+  int baz(double p);
+  int baz(int[] p);
+  int baz(char[] p);
+}

--- a/test/java/com/rpl/InterfaceB.java
+++ b/test/java/com/rpl/InterfaceB.java
@@ -1,0 +1,5 @@
+package com.rpl;
+
+public interface InterfaceB {
+  String bar(Integer x, Integer y, Integer z);
+}


### PR DESCRIPTION
…ifferent types

Switching away from number of params, to the actual param symbols, when looking for matching methods

Considering non-nil type hints on param symbols when looking for matches against the proxy class's declared methods

Adding test for contrived interface as well as java.io.Writer (mentioned in the issue)