### PR TITLE
better support for over-specified abstract class hierarchies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+* If there are multiple matching superclass methods, we now pick the last one.
+
 ## 0.0.2
 
 * Use type hints to distinguish methods of same name and arity (thanks @jeff303)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rpl/proxy-plus "0.0.2"
+(defproject com.rpl/proxy-plus "0.0.3"
   :description "A faster and more usable replacement for Clojure's proxy."
   :java-source-paths ["test/java"]
   :test-paths ["test/clj"]

--- a/src/com/rpl/proxy_plus.clj
+++ b/src/com/rpl/proxy_plus.clj
@@ -92,17 +92,18 @@
   (let [matching (filter
                     (fn [^Method m]
                       (and (= (.getName m) name)
-                           (type-hints-match (rest all-param-types) (-> m .getParameterTypes))
+                           (type-hints-match (rest all-param-types)
+                                             (-> m .getParameterTypes))
                            ))
                     (concat
                       (get-protected-methods klass)
                       (.getMethods klass)))]
     (cond
+      ;; there was more than one match, but the last one is the one that is
+      ;; closest to the base class we specified in the proxy+ decl block, so
+      ;; let's just use that one.
       (> (count matching) 1)
-      (throw
-        (ex-info
-          "Too many matching methods"
-          {:base klass :name name :methods (seq matching)}))
+      (last matching)
 
       (= (count matching) 0)
       (throw (ex-info "No matching methods" {:base klass :name name}))

--- a/test/clj/com/rpl/proxy_plus_test.clj
+++ b/test/clj/com/rpl/proxy_plus_test.clj
@@ -1,8 +1,9 @@
 (ns com.rpl.proxy-plus-test
   (:use [clojure.test]
         [com.rpl.proxy-plus])
-  (:import [com.rpl TestBaseClass TestBaseClass2 InterfaceA
-                    InterfaceB InterfaceC]))
+  (:import [com.rpl TestBaseClass TestBaseClass2
+            InterfaceA InterfaceB InterfaceC InterfaceD
+            AbstractBaseClass1 AbstractBaseClass2]))
 
 (deftest nothing-test
   (let [o (proxy+ [])
@@ -27,6 +28,15 @@
     (is (= 3 (.foo o "aaa")))
     (is (= 5 (.foo o "edcba")))
     ))
+
+(deftest multiple-levels-of-base-classes-test
+  (let [o (proxy+
+           []
+           AbstractBaseClass2
+           (foo [_this ^Integer x ^String y])
+           (bar [_this ^Integer x ^Integer y ^long z])
+           )])
+  )
 
 (definterface I1
   (^String foo [^Long l ^long l2])

--- a/test/java/com/rpl/AbstractBaseClass1.java
+++ b/test/java/com/rpl/AbstractBaseClass1.java
@@ -1,0 +1,11 @@
+package com.rpl;
+
+public abstract class AbstractBaseClass1 implements InterfaceD {
+
+  public String bar(Integer x, Integer y, long z) {
+    return null;
+  };
+
+  protected abstract String foo (Integer x, String y);
+
+}

--- a/test/java/com/rpl/AbstractBaseClass2.java
+++ b/test/java/com/rpl/AbstractBaseClass2.java
@@ -1,0 +1,5 @@
+package com.rpl;
+
+public abstract class AbstractBaseClass2 extends AbstractBaseClass1 {
+  protected abstract String foo (Integer x, String y);
+}

--- a/test/java/com/rpl/InterfaceD.java
+++ b/test/java/com/rpl/InterfaceD.java
@@ -1,0 +1,5 @@
+package com.rpl;
+
+public interface InterfaceD {
+  public String bar(Integer x, Integer y, long z);
+}


### PR DESCRIPTION
If there are multiple matches for a method's signature, we can choose the last one, because that will be the one that's from the superclass lowest in the hierarchy.