### PR TITLE
Several usability improvements

### DIFF
--- a/src/com/rpl/proxy_plus.clj
+++ b/src/com/rpl/proxy_plus.clj
@@ -74,7 +74,13 @@
        booleans (type (boolean-array []))
        chars (type (char-array []))
        (resolve tag) ; default, just return the resolved tag (which should be a Class)
-     )] (identical? compare-class param-class))
+       )]
+     (when (nil? compare-class)
+       (throw (ex-info (str "Type hint "
+                            tag
+                            " resolved to nil. Make sure that type is imported!")
+                       {})))
+     (.isAssignableFrom param-class compare-class))
   )
 )
 

--- a/test/clj/com/rpl/proxy_plus_test.clj
+++ b/test/clj/com/rpl/proxy_plus_test.clj
@@ -197,5 +197,27 @@
   (let [o (proxy+ my-proxy [])]
     (is (= (.getName (class o))
            "com.rpl.proxy_plus_test.my_proxy"))
-    )
+    ))
+
+(definterface I6
+  (^String foo [^java.util.Map m])
+  );
+
+(deftest assignable-from-test
+  (let [o (proxy+
+           []
+           I6
+           (foo [_this ^java.util.HashMap m] "woo")
+           )])
+  )
+
+(deftest throws-on-busted-type-hint-test
+  (is (thrown? Exception
+               ;; eval here so that the test namespace as a whole compiles, even
+               ;; though this produces a compile-time error!
+               (eval '(proxy+
+                       []
+                       I6
+                       (foo [_this ^SuperDuperMap m] "woo")
+                       ))))
   )

--- a/test/clj/com/rpl/proxy_plus_test.clj
+++ b/test/clj/com/rpl/proxy_plus_test.clj
@@ -201,6 +201,7 @@
 
 (definterface I6
   (^String foo [^java.util.Map m])
+  (^String foo [^java.util.HashMap m])
   );
 
 (deftest assignable-from-test
@@ -208,7 +209,12 @@
            []
            I6
            (foo [_this ^java.util.HashMap m] "woo")
-           )])
+           (foo [_this ^java.util.Map m] "wee")
+
+           )]
+    (is (= "wee" (.foo o (java.util.TreeMap.))))
+    (is (= "woo" (.foo o (java.util.HashMap.))))
+    )
   )
 
 (deftest throws-on-busted-type-hint-test


### PR DESCRIPTION
- use isAssignableFrom to support type hints that are sub classes
- throw a useful error when a type hint resolves to nil instead of an 
actual class