### PR TITLE
Remove Class/forName used in proxy+

### DIFF
--- a/src/com/rpl/proxy_plus.clj
+++ b/src/com/rpl/proxy_plus.clj
@@ -327,7 +327,7 @@
         klass (define-proxy-class proxy-name-sym decls)
         class-name (.getName klass)]
 
-    (.importClass ^clojure.lang.Namespace *ns* (Class/forName class-name))
+    (.importClass ^clojure.lang.Namespace *ns* klass)
     (let [inst-sym (with-meta (gensym "inst")
                      {:tag (symbol class-name)})
           all-impls (->> decls


### PR DESCRIPTION
Using `Class/forName` in the `.importClass` call in `proxy+` is not necessary, as the class is already loaded by its definition (`define-class`). The `Class/forName` usage causes problems when `proxy+` is AOT'd as the root classloader attempts to load the proxy class, which is only available/defined in a child `DynamicClassLoader`.