### PR TITLE
clj-kondo support & tidy .jar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,5 @@
 (defproject com.rpl/proxy-plus "0.0.12-SNAPSHOT"
   :description "A faster and more usable replacement for Clojure's proxy."
-  :java-source-paths ["test/java"]
   :test-paths ["test/clj"]
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [com.rpl/rama-shaded-asm "4.2"]]
@@ -10,6 +9,7 @@
    {:url
     "https://nexus.redplanetlabs.com/repository/maven-public-releases"}}
 
-  :profiles {:bench {:dependencies [[criterium "0.4.5"]]}
+  :profiles {:dev {:java-source-paths ["test/java"]}
+             :bench {:dependencies [[criterium "0.4.5"]]}
              }
   )

--- a/resources/clj-kondo.exports/com/rpl/config.edn
+++ b/resources/clj-kondo.exports/com/rpl/config.edn
@@ -1,0 +1,2 @@
+{:hooks {:analyze-call {com.rpl.proxy-plus/proxy+ hooks.proxy-plus/proxy+}}
+ :linters {:proxy-plus/superclass-args {:level :error}}}

--- a/resources/clj-kondo.exports/com/rpl/hooks/proxy_plus.clj
+++ b/resources/clj-kondo.exports/com/rpl/hooks/proxy_plus.clj
@@ -1,0 +1,64 @@
+(ns hooks.proxy-plus
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn proxy+
+  [{:keys [node]}]
+  (let [{:keys [children]}
+        node
+
+        ;; Consume `proxy+` token
+        children (rest children)
+
+        ;; Consume ClassNameSymbol. Not used for anything
+        name (if (-> children first api/token-node?)
+                (first children)
+                nil)
+        children (if name (rest children) children)
+
+        ;; Consume super-args. We require:
+        superclass-args (first children)
+        impl-body (rest children)
+
+        new-superclass
+        (api/list-node
+          ;; Check with (new Baseclass arg1 arg2 ...)
+          (list*
+            (api/token-node 'new)
+            (api/token-node 'java.lang.Object)
+            (:children superclass-args)))
+
+        reify-node
+        (api/list-node
+          (list*
+            (api/token-node 'reify)
+            impl-body))
+
+        new-node (api/list-node
+                   (list
+                     (api/token-node 'do)
+                     new-superclass
+                     reify-node))]
+    ;; For linting purposes we macroexpand the proxy+ call to:
+    ;;
+    ;; (do
+    ;;   (new java.lang.Object ~@super-args)
+    ;;   (reify ~@impl-body))
+    ;;
+    ;; generated code can be viewed with:
+    ;; (prn (api/sexpr new-node))
+    ;;
+    ;; # Notes
+    ;;
+    ;; We also check that super-args is a vector.
+    ;;
+    ;; We assume java.lang.Object as the superclass, at the time of writing
+    ;; linters don't check the arguments passed to java constructors for
+    ;; correctness and it is not easy to tell if there is a real base class
+    ;; or if we are proxying an interface.
+
+    (when-not (api/vector-node? superclass-args)
+      (api/reg-finding! (assoc (-> children first meta)
+                          :message (format "Superclass arguments '%s' should be a vector" superclass-args)
+                          :type :proxy-plus/superclass-args)))
+
+    {:node new-node}))


### PR DESCRIPTION
Hi! 

This addresses closed Issue #14. `{:clj-kondo/config '{:lint-as {com.rpl.proxy-plus/proxy+ clojure.core/proxy}}}` was suggested as a linter hint. This hint is incorrect since the syntax of `proxy+` is different from `proxy`. To lint this properly is a little involved. Getting the directory structure right in `resources/` was a pain - I think I've gotten it and I did check it.

I note that a linting hint was specifically rejected in #14 as a maintenance burden. Therefore no hard feelings if this is closed without comment. However I don't think people will figure this out for themselves without support from `proxy-plus+`. 

Also addresses #10 of test classes in the jar file.